### PR TITLE
Move LoginController unit tests to AuthModule folder

### DIFF
--- a/tests/WSReciboAcomodoITK.NetCoreAPI.Tests/AuthModule/LoginControllerTests.cs
+++ b/tests/WSReciboAcomodoITK.NetCoreAPI.Tests/AuthModule/LoginControllerTests.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Mvc;
+using WSReciboAcomodoITK.NetCoreAPI.API.Controllers;
+using NUnit.Framework;
+
+namespace WSReciboAcomodoITK.NetCoreAPI.Tests.AuthModule
+{
+    public class LoginControllerTests
+    {
+        [Test]
+        public void Login_WithValidCredentials_ReturnsToken()
+        {
+            var controller = new LoginController();
+            var request = new LoginRequest { Username = "admin", Password = "password" };
+            var result = controller.Login(request) as OkObjectResult;
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Value?.ToString(), Does.Contain("token"));
+        }
+
+        [Test]
+        public void Login_WithInvalidCredentials_ReturnsUnauthorized()
+        {
+            var controller = new LoginController();
+            var request = new LoginRequest { Username = "user", Password = "wrong" };
+            var result = controller.Login(request);
+            Assert.That(result, Is.InstanceOf<UnauthorizedResult>());
+        }
+    }
+}


### PR DESCRIPTION
This PR moves the LoginController unit tests into a dedicated AuthModule folder for better organization and maintainability. No test logic was changed; only the file location was updated.